### PR TITLE
Fix "can should" typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
             <a href="https://tink.uk/using-the-aria-current-attribute/">Using the <code>aria-current</code> attribute</a> by Léonie Watson.
           </p>
           <p>
-            Additionally, can should review
+            Additionally, you should review
             <a href="https://w3c.github.io/aria-practices/examples/breadcrumb/index.html">the <abbr>ARIA</abbr> Authoring Practices breadcrumbs example</a>,
             as well as the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-current">ARIA specification for <code>aria-current</code></a>.
           </p>


### PR DESCRIPTION
I opted for `you should` vs `you can`, but can change depending on the tone you're looking for :)